### PR TITLE
Refactor 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,30 +5,65 @@ database VM) of XNAT or OMERO.
 
 ## Role Variables
 
-See defaults/main.yml for the full list.
+See `defaults/main.yml` for the full list.
 
-- `allow_collaborator_access`: Allow access to IP addresses/ranges listed in
-  `collaborator_networks`. Defaults to `false`.
 - `allow_public_access`: Allow access from an IP address. Defaults to `false`.
-- `collaborator_networks`: A list of IP addresses/ranges of UCL collaborating
-  partners. Defaults to `[]`.
-- `work_networks`: List of public UCL IP addresses/ranges requiring access to
-  the `work` zone. Defaults to `[]`.
-- `internal_networks`: List of private internal UCL IP addresses/ranges.
+- `internal_zone_open_services`: A list of services to allow in the `internal`
+  zone. Defaults to:
+  ```
+  - http
+  - https
+  - ssh
+  ```
+- `public_zone_open_services`: A list of services to allow in the `public` zone.
+  Defaults to:
+  ```
+  - http
+  - https
+  ```
+- `work_zone_open_services`: A list of services to allow in the `work` zone.
+  Defaults to:
+  ```
+  - http
+  - https
+  ```
+- `internal_zone_closed_services`: A list of services to not allow in the
+  `internal` zone. Defaults to:
+  ```
+  - samba-client
+  ```
+- `public_zone_closed_services`: A list of services to not allow in the `public`
+  zone. Defaults to:
+  ```
+  - ssh
+  ```
+- `work_zone_closed_services`: A list of services to not allow in the `work`
+  zone. Defaults to:
+  ```
+  - ssh
+  ```
+- `internal_zone_sources`: A list of IP addresses to allow in `internal` zone.
   Defaults to `[]`.
-- `internal_port`: A port to open on the internal zone (typically for
-  Postgresql). Defaults to `""`.
-- `open_internal_zone_to_server_ip`: Add a rich rule to accept traffic on the
-  `internal` zone on this IP address (typically for connecting the web
-  application to Postgresql). Defaults to `""`.
-- `vm_firewall_type`: Used to determine the services required by the VM firewall
-  configuration. Valid options are `"web"` or `"db"`. A "web" configuration will
-  allow connections via SSH, HTTP and HTTPS for IP address defined in
-  `internal_networks`, `work_networks` and `collaborator_networks`. Defaults to
-  `"web"`.
-- `web_rich_rules`: Any other rich rules to add. Defaults to `[]`.
-- `zone_ports`: Additional ports to open for `internal` and `work`
-  zones.Defaults to `[]`.
+- `public_zone_sources`: A list of IP addresses to allow in `public` zone.
+  Defaults to `[]`.
+- `work_zone_sources`: A list of IP addresses to allow in `work` zone. Defaults
+  to `[]`.
+- `internal_zone_ports`: A list of ports to allow in `internal` zone. Defaults
+  to `[]`.
+- `work_zone_ports`: A list of ports to allow in `public` zone. Defaults to
+  `[]`.
+- `public_zone_ports`: A list of ports to allow in `work` zone. Defaults to
+  `[]`.
+- `allow_inter_vm_connections`: A boolean which indicates whether the firewall
+  accepts connections from another VM in the network. Defaults to `false`.
+- `inter_vm_rules`: Rules to apply when `allow_inter_vm_connections` is `true`.
+  Defaults to:
+  ```
+  - ip: ""
+    port: ""
+  ```
+- `rich_rules`: A list of hashes defining rich rules to apply. The zone to apply
+  the rule to should be a key in the hash.
 
 ## Installation
 
@@ -36,7 +71,7 @@ Include in a `requirements.yml` file as follows:
 
 ```yaml
 - src: https://github.com/UCL-MIRSG/ansible-role-dual-vm-firewalld.git
-  version: main
+  version: 2022.12.22.0
   name: mirsg.firewalld
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,6 +49,7 @@ zone_ports:
   public: "{{ public_zone_ports }}"
   work: "{{ work_zone_ports }}"
 
+allow_inter_vm_connections: false
 inter_vm_rules:
   - ip: ""
     port: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,15 +4,9 @@ allow_public_access: false
 
 # IP ranges allowing HTTP/HTTPS
 internal_zone_open_services:
-  - http
-  - https
   - ssh
-public_zone_open_services:
-  - http
-  - https
-work_zone_open_services:
-  - http
-  - https
+public_zone_open_services: []
+work_zone_open_services: []
 
 internal_zone_closed_services:
   - samba-client

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,8 +26,8 @@ work_zone_sources: []
 public_zone_sources: []
 
 internal_zone_ports: []
-work_zone_ports: []
 public_zone_ports: []
+work_zone_ports: []
 
 close_zone_services:
   internal: "{{ internal_zone_closed_services }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,29 +1,57 @@
 ---
-# defaults file for ../mirsg-firewall-ansible-role
-vm_firewall_type: "web"
-zone_ports: []
-open_internal_zone_to_server_ip: ""
-internal_port: ""
-# IP ranges allowing HTTP/HTTPS
-internal_networks:
-  # UCL CS (128.16.0.0/20 main network; 128.16.0.0/16 full network)
-  - "128.16.0.0/16"
-work_networks:
-  # UCL public IP addresses (does not include CS network)
-  # see: https://www.ucl.ac.uk/isd/services/get-connected/wired-networks/about-wired-networks/ucl-internet-protocol-ip-addresses
-  - "128.40.0.0/16"
-  - "128.41.0.0/18"
-  - "144.82.0.0/16"
-  - "193.60.221.0/24"
-  - "193.60.224.0/19"
-  - "212.219.75.0/24"
-
-  # UCL routed internal addresses (private addresses that UCL routes internally)
-  # see: https://www.ucl.ac.uk/isd/services/get-connected/wired-networks/use-private-rfc1918-address-space-ucl-internal-network
-  - "10.0.0.0/9"
-  - "172.16.0.0/13"
-  - "192.168.0.0/17"
-collaborator_networks: []
+# defaults file for ../ansible-role-dual-vm-firewalld
 allow_public_access: false
-allow_collaborator_access: false
-web_rich_rules: []
+
+# IP ranges allowing HTTP/HTTPS
+internal_zone_open_services:
+  - http
+  - https
+  - ssh
+public_zone_open_services:
+  - http
+  - https
+work_zone_open_services:
+  - http
+  - https
+
+internal_zone_closed_services:
+  - samba-client
+public_zone_closed_services:
+  - ssh
+work_zone_closed_services:
+  - ssh
+
+internal_zone_sources: []
+work_zone_sources: []
+public_zone_sources: []
+
+internal_zone_ports: []
+work_zone_ports: []
+public_zone_ports: []
+
+close_zone_services:
+  internal: "{{ internal_zone_closed_services }}"
+  public: "{{ public_zone_closed_services }}"
+  work: "{{ work_zone_closed_services }}"
+
+open_zone_services:
+  internal: "{{ internal_zone_open_services }}"
+  public: "{{ public_zone_open_services }}"
+  work: "{{ work_zone_open_services }}"
+
+zone_sources:
+  internal: "{{ internal_zone_sources }}"
+  public: "{{ public_zone_sources }}"
+  work: "{{ work_zone_sources }}"
+
+zone_ports:
+  internal: "{{ internal_zone_ports }}"
+  public: "{{ public_zone_ports }}"
+  work: "{{ work_zone_ports }}"
+
+inter_vm_rules:
+  - ip: ""
+    port: ""
+
+# rich_rules should be a list of hashes
+rich_rules: []

--- a/molecule/resources/inventory/group_vars/db/vars
+++ b/molecule/resources/inventory/group_vars/db/vars
@@ -4,6 +4,7 @@ internal_networks:
   - "172.17.0.0/24"
 work_networks:
   - "0.0.0.0/0"
+allow_inter_vm_connections: true
 inter_vm_rules:
   - ip: "172.17.0.3"
     port: "5432"

--- a/molecule/resources/inventory/group_vars/db/vars
+++ b/molecule/resources/inventory/group_vars/db/vars
@@ -1,6 +1,9 @@
 ---
-vm_firewall_type: "db"
 allow_public_access: false
-open_internal_zone_to_server_ip: "172.17.0.3"
-internal_port: "5432"
-zone_ports: []
+internal_networks:
+  - "172.17.0.0/24"
+work_networks:
+  - "0.0.0.0/0"
+inter_vm_rules:
+  - ip: "172.17.0.3"
+    port: "5432"

--- a/molecule/resources/inventory/group_vars/docker/vars
+++ b/molecule/resources/inventory/group_vars/docker/vars
@@ -1,7 +1,14 @@
 ---
-collaborator_networks: []
-work_networks:
-  - "0.0.0.0/0"
-internal_networks:
+internal_zone_closed_services:
+  - samba-client
+public_zone_closed_services:
+  - ssh
+work_zone_closed_services:
+  - ssh
+
+internal_zone_sources:
   - "172.17.0.0/16"
-web_rich_rules: []
+public_zone_sources: []
+work_zone_sources:
+  - "0.0.0.0/0"
+rich_rules: []

--- a/molecule/resources/inventory/group_vars/web/vars
+++ b/molecule/resources/inventory/group_vars/web/vars
@@ -1,6 +1,9 @@
 ---
-vm_firewall_type: "web"
 allow_public_access: true
-zone_ports:
+internal_networks:
+  - "172.17.0.0/24"
+work_networks:
+  - "0.0.0.0/0"
+internal_zone_ports:
   - "4063"
   - "4064"

--- a/molecule/resources/inventory/group_vars/web/vars
+++ b/molecule/resources/inventory/group_vars/web/vars
@@ -1,5 +1,15 @@
 ---
 allow_public_access: true
+internal_zone_open_services:
+  - http
+  - https
+  - ssh
+public_zone_open_services:
+  - http
+  - https
+work_zone_open_services:
+  - http
+  - https
 internal_networks:
   - "172.17.0.0/24"
 work_networks:

--- a/molecule/resources/verify.yml
+++ b/molecule/resources/verify.yml
@@ -2,22 +2,6 @@
   hosts: all
   gather_facts: false
   tasks:
-    - name: Get services in public zone
-      become: true
-      ansible.builtin.shell: |
-        set -o pipefail
-        firewall-cmd --list-services --zone=public
-      register: public_zone_services
-      changed_when: false
-      failed_when: false
-
-    - name: Test that HTTP and HTTPS are in public zone
-      ansible.builtin.assert:
-        that:
-          - "'http' in public_zone_services.stdout"
-          - "'https' in public_zone_services.stdout"
-      when: vm_firewall_type == "web"
-
     - name: Get services in internal zone
       become: true
       ansible.builtin.shell: |
@@ -27,24 +11,65 @@
       changed_when: false
       failed_when: false
 
-    - name: Test that HTTP, HTTPS are in internal zone for web VM
-      ansible.builtin.assert:
-        that:
-          - "'http' in internal_zone_services.stdout"
-          - "'https' in internal_zone_services.stdout"
-      when: vm_firewall_type == "web"
+    - name: Get services in public zone
+      become: true
+      ansible.builtin.shell: |
+        set -o pipefail
+        firewall-cmd --list-services --zone=public
+      register: public_zone_services
+      changed_when: false
+      failed_when: false
 
-    - name: Test that HTTP, HTTPS are not in internal zone for db VM
-      ansible.builtin.assert:
-        that:
-          - "'http' not in internal_zone_services.stdout"
-          - "'https' not in internal_zone_services.stdout"
-      when: vm_firewall_type == "db"
+    - name: Get services in work zone
+      become: true
+      ansible.builtin.shell: |
+        set -o pipefail
+        firewall-cmd --list-services --zone=work
+      register: work_zone_services
+      changed_when: false
+      failed_when: false
 
-    - name: Test that SSH is in internal zone
+    - name: Test that correct services are in internal zone
       ansible.builtin.assert:
         that:
-          - "'ssh' in internal_zone_services.stdout"
+          - "'{{ item }}' in internal_zone_services.stdout"
+      loop: "{{ internal_zone_open_services }}"
+      when: internal_zone_open_services is defined
+
+    - name: Test that correct services are in public zone
+      ansible.builtin.assert:
+        that:
+          - "'{{ item }}' in public_zone_services.stdout"
+      loop: "{{ public_zone_open_services }}"
+      when: public_zone_open_services is defined
+
+    - name: Test that correct services are in work zone
+      ansible.builtin.assert:
+        that:
+          - "'{{ item }}' in work_zone_services.stdout"
+      loop: "{{ work_zone_open_services }}"
+      when: work_zone_open_services is defined
+
+    - name: Test that internal zone is closed to the correct services
+      ansible.builtin.assert:
+        that:
+          - "'{{ item }}' not in internal_zone_services.stdout"
+      loop: "{{ internal_zone_closed_services }}"
+      when: internal_zone_closed_services is defined
+
+    - name: Test that public zone is closed to the correct services
+      ansible.builtin.assert:
+        that:
+          - "'{{ item }}' not in public_zone_services.stdout"
+      loop: "{{ public_zone_closed_services }}"
+      when: public_zone_closed_services is defined
+
+    - name: Test that work zone is closed to the correct services
+      ansible.builtin.assert:
+        that:
+          - "'{{ item }}' not in work_zone_services.stdout"
+      loop: "{{ work_zone_closed_services }}"
+      when: work_zone_closed_services is defined
 
     - name: Get firewall default zone
       become: true
@@ -55,12 +80,12 @@
       changed_when: false
       failed_when: false
 
-    - name: Example assertion
+    - name: Assert that public is the default zone
       ansible.builtin.assert:
         that: "'public' in firewall_default_zone.stdout"
       when: allow_public_access
 
-    - name: Example assertion
+    - name: Assert that drop is the default zone
       ansible.builtin.assert:
         that: "'drop' in firewall_default_zone.stdout"
       when: not allow_public_access

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,208 +1,54 @@
 ---
-# tasks file for ../mirsg-firewall-ansible-role
-- name: Get hosts group
-  ansible.builtin.debug:
-    msg: "{{ vm_firewall_type }}"
-
-- name: Assert hosts group
-  ansible.builtin.assert:
-    that:
-      - vm_firewall_type == "web" or vm_firewall_type == "db"
-
-- name: Enable firewalld
-  become: true
-  ansible.builtin.service:
-    name: firewalld
-    state: started
-    enabled: true
-
-# internal zone config
-- name: Ensure internal zone is open to ssh
+# tasks file for ../ansible-role-dual-vm-firewalld
+- name: Close zones to services
   become: true
   ansible.posix.firewalld:
-    zone: internal
-    service: ssh
-    immediate: true
-    permanent: true
-    state: enabled
-
-- name: Ensure no samba-client for internal zone
-  become: true
-  ansible.posix.firewalld:
-    zone: internal
-    service: samba-client
+    zone: "{{ item.0.key }}"
+    service: "{{ item.1 }}"
     immediate: true
     permanent: true
     state: disabled
+  loop: "{{ close_zone_services | dict2items | subelements('value') }}"
 
-- name: Open internal zone to https
+- name: Open zones to services
   become: true
   ansible.posix.firewalld:
-    zone: internal
-    service: https
+    zone: "{{ item.0.key }}"
+    service: "{{ item.1 }}"
     immediate: true
     permanent: true
     state: enabled
-  when: vm_firewall_type == "web"
+  loop: "{{ open_zone_services | dict2items | subelements('value') }}"
 
-- name: Open internal zone to http
+- name: Open zones to sources
   become: true
   ansible.posix.firewalld:
-    zone: internal
-    service: http
-    immediate: true
-    permanent: true
-    state: enabled
-  when: vm_firewall_type == "web"
-
-- name: Ensure internal zone is open to specified ports
-  become: true
-  ansible.posix.firewalld:
-    zone: internal
-    port: "{{ item }}/tcp"
-    immediate: true
-    permanent: true
-    state: enabled
-  with_items:
-    - "{{ zone_ports }}"
-
-- name: Add to internal zone - {{ items }}
-  become: true
-  ansible.posix.firewalld:
-    zone: internal
-    source: "{{ item }}"
+    zone: "{{ item.0.key }}"
+    source: "{{ item.1 }}"
     permanent: true
     immediate: true
     state: enabled
-  with_items:
-    - "{{ internal_networks }}"
-# end internal zone config
+  loop: "{{ zone_sources | dict2items | subelements('value') }}"
 
-# public zone config
-- name: Ensure public zone is not open to ssh
+- name: Open zones to ports
   become: true
   ansible.posix.firewalld:
-    zone: public
-    service: ssh
-    immediate: true
-    permanent: true
-    state: disabled
-
-- name: Open public zone to https
-  become: true
-  ansible.posix.firewalld:
-    zone: public
-    service: https
+    zone: "{{ item.0.key }}"
+    port: "{{ item.1 }}/tcp"
     immediate: true
     permanent: true
     state: enabled
-  when: vm_firewall_type == "web"
+  loop: "{{ zone_ports | dict2items | subelements('value') }}"
 
-- name: Open public zone to http
+- name: Allow inter-vm connections
   become: true
   ansible.posix.firewalld:
-    zone: public
-    service: http
-    immediate: true
-    permanent: true
-    state: enabled
-  when: vm_firewall_type == "web"
-
-- name: Add collaborator networks to public zone - {{ items }}
-  become: true
-  when: vm_firewall_type == "web" and allow_collaborator_access|bool
-  ansible.posix.firewalld:
-    zone: public
-    source: "{{ item }}"
-    permanent: true
-    immediate: true
-    state: enabled
-  with_items:
-    - "{{ collaborator_networks | default([]) }}"
-# end public zone config
-
-# work zone config
-- name: Ensure work zone is not open to ssh
-  become: true
-  ansible.posix.firewalld:
-    zone: work
-    service: ssh
-    immediate: true
-    permanent: true
-    state: disabled
-
-- name: Open work zone to https
-  become: true
-  ansible.posix.firewalld:
-    zone: work
-    service: https
-    immediate: true
-    permanent: true
-    state: enabled
-  when: vm_firewall_type == "web"
-
-- name: Open work zone to http
-  become: true
-  ansible.posix.firewalld:
-    zone: work
-    service: http
-    immediate: true
-    permanent: true
-    state: enabled
-  when: vm_firewall_type == "web"
-
-- name: Ensure work zone is open to specified ports
-  become: true
-  ansible.posix.firewalld:
-    zone: work
-    port: "{{ item }}/tcp"
-    immediate: true
-    permanent: true
-    state: enabled
-  with_items:
-    - "{{ zone_ports }}"
-  when: vm_firewall_type == "web"
-
-- name: Add to work zone {{ items }}
-  become: true
-  ansible.posix.firewalld:
-    zone: work
-    source: "{{ item }}"
-    permanent: true
-    immediate: true
-    state: enabled
-  with_items:
-    - "{{ work_networks }}"
-  when: vm_firewall_type == "web"
-# end work zone config
-
-- name: Check firewall default zone
-  become: true
-  ansible.builtin.shell: |
-    set -o pipefail
-    firewall-cmd --get-default-zone | grep -i drop
-  register: firewall_db_default_zone
-  changed_when: false
-  failed_when: false
-
-- name: Check firewall default zone
-  become: true
-  ansible.builtin.shell: |
-    set -o pipefail
-    firewall-cmd --get-default-zone | grep -i {% if allow_public_access %}public{% else %}drop{% endif %}
-  register: firewall_web_default_zone
-  changed_when: false
-  failed_when: false
-
-- name: Open internal port {{ internal_port }}
-  become: true
-  ansible.posix.firewalld:
-    rich_rule: "rule family=ipv4 source address={{ open_internal_zone_to_server_ip }}/32 port protocol=tcp port={{ internal_port }} accept"
+    rich_rule: "rule family=ipv4 source address={{ item.ip }}/32 port protocol=tcp port={{ item.port }} accept"
     zone: internal
     permanent: true
     immediate: true
     state: enabled
-  when: vm_firewall_type == "db"
+  loop: "{{ inter_vm_rules }}"
 
 - name: Add firewall rich rules
   become: true
@@ -212,17 +58,20 @@
     permanent: true
     immediate: true
     state: enabled
-  loop: "{{ web_rich_rules | default([]) }}"
-  when: vm_firewall_type == "web"
+  loop: "{{ rich_rules | default([]) }}"
 
-- name: Drop all db default connections
+- name: Check firewall default zone
   become: true
-  ansible.builtin.command: firewall-cmd --set-default-zone=drop
-  when: firewall_db_default_zone.rc != 0 and vm_firewall_type == "db"
+  ansible.builtin.shell: |
+    set -o pipefail
+    firewall-cmd --get-default-zone | grep -i {% if allow_public_access %}public{% else %}drop{% endif %}
+  register: firewall_default_zone
+  changed_when: false
+  failed_when: false
 
-- name: Allow or drop web default connections
+- name: Allow or drop default connections
   become: true
   ansible.builtin.command: >-
     firewall-cmd
     --set-default-zone={% if allow_public_access %}public{% else %}drop{% endif %}
-  when: firewall_web_default_zone.rc != 0 and vm_firewall_type == "web"
+  when: firewall_default_zone.rc != 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,6 +49,7 @@
     immediate: true
     state: enabled
   loop: "{{ inter_vm_rules }}"
+  when: allow_inter_vm_connections
 
 - name: Add firewall rich rules
   become: true


### PR DESCRIPTION
Closes #5 

Refactor tasks to be more generic. Allows users of the role to specify:

1. Services to open for internal, public and work zones
2. Services to close for internal, public and work zones
3. Sources (IP ranges) for internal, public and work zones
4. Ports to open for internal, public and work zones
5. IP addresses and ports (rules) for inter VM communication (such as between web and database VMs)
6. The default zone to use (public zone for public access and drop zone for internal)